### PR TITLE
Convenience Recipes

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,7 +12,7 @@ plugins {
 }
 
 group = "me.ShermansWorld"
-version = "1.20.0"
+version = "1.21.0"
 description = ""
 val mainPackage = "${project.group}.${rootProject.name}"
 
@@ -123,7 +123,7 @@ tasks {
 
     runServer {
         // Configure the Minecraft version for our task.
-        minecraftVersion("1.20.1")
+        minecraftVersion("1.20.4")
 
         // IntelliJ IDEA debugger setup: https://docs.papermc.io/paper/dev/debugging#using-a-remote-debugger
         jvmArgs("-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005", "-DPaper.IgnoreJavaVersion=true", "-Dcom.mojang.eula.agree=true", "-DIReallyKnowWhatIAmDoingISwear")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,7 +12,7 @@ plugins {
 }
 
 group = "me.ShermansWorld"
-version = "1.21.0"
+version = "1.21.1"
 description = ""
 val mainPackage = "${project.group}.${rootProject.name}"
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,7 +12,7 @@ plugins {
 }
 
 group = "me.ShermansWorld"
-version = "1.21.2"
+version = "1.21.3"
 description = ""
 val mainPackage = "${project.group}.${rootProject.name}"
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,7 +12,7 @@ plugins {
 }
 
 group = "me.ShermansWorld"
-version = "1.21.1"
+version = "1.21.2"
 description = ""
 val mainPackage = "${project.group}.${rootProject.name}"
 

--- a/src/main/java/me/ShermansWorld/AlathraExtras/AlathraExtras.java
+++ b/src/main/java/me/ShermansWorld/AlathraExtras/AlathraExtras.java
@@ -160,29 +160,7 @@ public class AlathraExtras extends JavaPlugin {
         furnaceRecipes.rottenFleshtoLeather();
         furnaceRecipes.mossyCobbletoAndesite();
 
-        CraftingRecipes craftingRecipes = new CraftingRecipes();
-        craftingRecipes.saddleRecipe();
-        craftingRecipes.charcoalBlock();
-        craftingRecipes.redDyeRecipe();
-        craftingRecipes.redSandRecipe();
-        craftingRecipes.bellRecipe();
-        craftingRecipes.blackDyeRecipe1();
-        craftingRecipes.blackDyeRecipe2();
-        craftingRecipes.beetRootPouchRecipe();
-        craftingRecipes.carrotPouchRecipe();
-        craftingRecipes.potatoPouchRecipe();
-        craftingRecipes.dioriteRecipe1();
-        craftingRecipes.dioriteRecipe2();
-        craftingRecipes.dioriteRecipe3();
-        craftingRecipes.greenDyeRecipe();
-        craftingRecipes.pinkPetalsRecipe();
-        craftingRecipes.stonesToGravel();
-        craftingRecipes.gravelToSand();
-        craftingRecipes.dioriteToQuartz();
-        craftingRecipes.coarseDirtToDirt();
-        craftingRecipes.beetrootPouchToBeetroot();
-        craftingRecipes.carrotPouchToCarrot();
-        craftingRecipes.potatoPouchToPotato();
+        CraftingRecipes.registerAllCraftingRecipes();
 
         StoneCuttingRecipes.setWoodcuttingRecipes();
         StoneCuttingRecipes.setBamboocuttingRecipes();

--- a/src/main/java/me/ShermansWorld/AlathraExtras/AlathraExtras.java
+++ b/src/main/java/me/ShermansWorld/AlathraExtras/AlathraExtras.java
@@ -20,9 +20,10 @@ import me.ShermansWorld.AlathraExtras.joinleavemessages.JoinLeaveMessages;
 import me.ShermansWorld.AlathraExtras.metrics.MetricsManager;
 import me.ShermansWorld.AlathraExtras.metrics.PlayerFirstJoinListener;
 import me.ShermansWorld.AlathraExtras.misc.CommandListener;
-import me.ShermansWorld.AlathraExtras.misc.CraftingListener;
+import me.ShermansWorld.AlathraExtras.misc.PaperRecipesListener;
 import me.ShermansWorld.AlathraExtras.misc.ItemFrameListener;
 import me.ShermansWorld.AlathraExtras.misc.MsgEditor;
+import me.ShermansWorld.AlathraExtras.crafting.CraftingListener;
 import me.ShermansWorld.AlathraExtras.playtime.PlaytimeCommand;
 import me.ShermansWorld.AlathraExtras.playtime.PlaytimeTabCompleter;
 import me.ShermansWorld.AlathraExtras.puke.HopperListener;
@@ -130,6 +131,7 @@ public class AlathraExtras extends JavaPlugin {
         this.getServer().getPluginManager().registerEvents(new EnderChestBlockListener(), this);
         this.getServer().getPluginManager().registerEvents(new EndermanExpDropListener(), this);
         this.getServer().getPluginManager().registerEvents(new DisableSpawners(), this);
+        this.getServer().getPluginManager().registerEvents(new DispenserListener(), this);
         this.getServer().getPluginManager().registerEvents(new FurnaceRecipesListener(), this);
         this.getServer().getPluginManager().registerEvents(new GrindstoneListener(), this);
         // this.getServer().getPluginManager().registerEvents(new HeadScourgeListener(), this);
@@ -139,6 +141,7 @@ public class AlathraExtras extends JavaPlugin {
         this.getServer().getPluginManager().registerEvents(new ItemFrameListener(), this);
         this.getServer().getPluginManager().registerEvents(new ItemsListener(), this);
         this.getServer().getPluginManager().registerEvents(new MsgEditor(), this);
+        this.getServer().getPluginManager().registerEvents(new PaperRecipesListener(), this);
         this.getServer().getPluginManager().registerEvents(new PlayerClickHelpBook(), this);
         this.getServer().getPluginManager().registerEvents(new PlayerCommandPreprocessListener(), this);
         this.getServer().getPluginManager().registerEvents(new PlayerFirstJoin(), this);
@@ -153,7 +156,6 @@ public class AlathraExtras extends JavaPlugin {
         this.getServer().getPluginManager().registerEvents(new TeleportRequestResponseListener(), this);
         this.getServer().getPluginManager().registerEvents(new TownyListener(), this);
         this.getServer().getPluginManager().registerEvents(new VotingListener(), this);
-        this.getServer().getPluginManager().registerEvents(new DispenserListener(), this);
 
         initRecipeItems();
         FurnaceRecipes furnaceRecipes = new FurnaceRecipes();

--- a/src/main/java/me/ShermansWorld/AlathraExtras/crafting/CraftingListener.java
+++ b/src/main/java/me/ShermansWorld/AlathraExtras/crafting/CraftingListener.java
@@ -1,5 +1,6 @@
 package me.ShermansWorld.AlathraExtras.crafting;
 
+import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
@@ -8,19 +9,141 @@ import org.bukkit.inventory.ItemStack;
 
 public class CraftingListener implements Listener {
     @EventHandler
-    public void furnaceOverride(PrepareItemCraftEvent event) {
-        ItemStack[] craftingGrid = event.getInventory().getMatrix();
+    public void stoneRecipeOverrides(PrepareItemCraftEvent event) {
+        ItemStack[] craftingGridItemStacks = event.getInventory().getMatrix();
+        Material[] craftingGrid = new Material[9];
 
-        if (craftingGrid[4] != null) return;
+        for (int a = 0; a <= 8; a++) {
+            if (craftingGridItemStacks[a] != null) {
+                craftingGrid[a] = craftingGridItemStacks[a].getType();
+            }
+        }
+
+        if (furnaceOverride(craftingGrid)) {
+            event.getInventory().setResult(new ItemStack(Material.FURNACE));
+
+            return;
+        }
+
+        if (slabOverride(craftingGrid, Material.COBBLESTONE)) {
+            event.getInventory().setResult(new ItemStack(Material.COBBLESTONE_SLAB, 6));
+
+            return;
+        }
+
+        if (slabOverride(craftingGrid, Material.COBBLED_DEEPSLATE)) {
+            event.getInventory().setResult(new ItemStack(Material.COBBLED_DEEPSLATE_SLAB, 6));
+
+            return;
+        }
+
+        if (wallOverride(craftingGrid, Material.COBBLESTONE)) {
+            event.getInventory().setResult(new ItemStack(Material.COBBLESTONE_WALL, 6));
+
+            return;
+        }
+
+        if (wallOverride(craftingGrid, Material.COBBLED_DEEPSLATE)) {
+            event.getInventory().setResult(new ItemStack(Material.COBBLED_DEEPSLATE_WALL, 6));
+
+            return;
+        }
+
+        if (stairOverride(craftingGrid, Material.COBBLESTONE)) {
+            event.getInventory().setResult(new ItemStack(Material.COBBLESTONE_STAIRS, 4));
+
+            return;
+        }
+
+        if (stairOverride(craftingGrid, Material.COBBLED_DEEPSLATE)) {
+            event.getInventory().setResult(new ItemStack(Material.COBBLED_DEEPSLATE_STAIRS, 4));
+
+            return;
+        }
+
+        if (polishedDeepslateOverride(craftingGrid)) {
+            event.getInventory().setResult(new ItemStack(Material.POLISHED_DEEPSLATE, 4));
+        }
+    }
+
+    public boolean furnaceOverride(Material[] craftingGrid) {
+        if (craftingGrid[4] != null) return false;
 
         for (int a = 0; a <= 8; a++) {
             if (a == 4) continue;
 
-            if (craftingGrid[a] == null) return;
+            if (craftingGrid[a] == null) return false;
 
-            if (craftingGrid[a].getType() != Material.COBBLESTONE) return;
+            boolean validMat = craftingGrid[a] == Material.COBBLESTONE;
+
+            if (craftingGrid[a] == Material.COBBLED_DEEPSLATE) validMat = true;
+
+            if (!validMat) return false;
         }
 
-        event.getInventory().setResult(new ItemStack(Material.FURNACE));
+        return true;
+    }
+
+    public boolean slabOverride(Material[] craftingGrid, Material material) {
+        Material[] slabRecipe1 = new Material[]{material, material, material, null, null, null, null, null, null};
+        Material[] slabRecipe2 = new Material[]{null, null, null, material, material, material, null, null, null};
+        Material[] slabRecipe3 = new Material[]{null, null, null, null, null, null, material, material, material};
+
+        if (recipeCheck(craftingGrid, slabRecipe1)) return true;
+
+        if (recipeCheck(craftingGrid, slabRecipe2)) return true;
+
+        return recipeCheck(craftingGrid, slabRecipe3);
+    }
+
+    public boolean wallOverride(Material[] craftingGrid, Material material) {
+        Material[] wallRecipe1 = new Material[]{material, material, material, material, material, material,
+            null, null, null};
+        Material[] wallRecipe2 = new Material[]{null, null, null, material, material, material,
+            material, material, material};
+
+        if (recipeCheck(craftingGrid, wallRecipe1)) return true;
+
+        return recipeCheck(craftingGrid, wallRecipe2);
+    }
+
+    public boolean stairOverride(Material[] craftingGrid, Material material) {
+        Material[] stairRecipe1 = new Material[]{material, null, null, material, material, null,
+            material, material, material};
+        Material[] stairRecipe2 = new Material[]{null, null, material, null, material, material,
+            material, material, material};
+
+        if (recipeCheck(craftingGrid, stairRecipe1)) return true;
+
+        return recipeCheck(craftingGrid, stairRecipe2);
+    }
+
+    public boolean polishedDeepslateOverride(Material[] craftingGrid) {
+        Material material = Material.COBBLED_DEEPSLATE;
+
+        Material[] polishedDeepslateRecipe1 = new Material[]{material, material, null, material, material, null,
+        null, null, null};
+        Material[] polishedDeepslateRecipe2 = new Material[]{null, material, material, null, material, material,
+        null, null, null};
+        Material[] polishedDeepslateRecipe3 = new Material[]{null, null, null, material, material, null,
+        material, material, null};
+        Material[] polishedDeepslateRecipe4 = new Material[]{null, null, null, null, material, material,
+        null, material, material};
+
+        if (recipeCheck(craftingGrid, polishedDeepslateRecipe1)) return true;
+
+        if (recipeCheck(craftingGrid, polishedDeepslateRecipe2)) return true;
+
+        if (recipeCheck(craftingGrid, polishedDeepslateRecipe3)) return true;
+
+        return recipeCheck(craftingGrid, polishedDeepslateRecipe4);
+    }
+
+    public boolean recipeCheck(Material[] craftingGrid, Material[] recipe) {
+        for (int a = 0; a <= 8; a++) {
+            if (craftingGrid[a] != recipe[a]) return false;
+        }
+
+        return true;
     }
 }

--- a/src/main/java/me/ShermansWorld/AlathraExtras/crafting/CraftingListener.java
+++ b/src/main/java/me/ShermansWorld/AlathraExtras/crafting/CraftingListener.java
@@ -1,0 +1,24 @@
+package me.ShermansWorld.AlathraExtras.crafting;
+
+import org.bukkit.Material;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.inventory.PrepareItemCraftEvent;
+import org.bukkit.inventory.ItemStack;
+
+public class CraftingListener implements Listener {
+    @EventHandler
+    public void furnaceOverride(PrepareItemCraftEvent event) {
+        ItemStack[] craftingGrid = event.getInventory().getMatrix();
+
+        if (craftingGrid[4] != null) return;
+
+        for (int a = 0; a <= 8; a++) {
+            if (a == 4) continue;
+
+            if (craftingGrid[a].getType() != Material.COBBLESTONE) return;
+        }
+
+        event.getInventory().setResult(new ItemStack(Material.FURNACE));
+    }
+}

--- a/src/main/java/me/ShermansWorld/AlathraExtras/crafting/CraftingListener.java
+++ b/src/main/java/me/ShermansWorld/AlathraExtras/crafting/CraftingListener.java
@@ -1,9 +1,9 @@
 package me.ShermansWorld.AlathraExtras.crafting;
 
-import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
+import org.bukkit.event.inventory.InventoryType;
 import org.bukkit.event.inventory.PrepareItemCraftEvent;
 import org.bukkit.inventory.ItemStack;
 
@@ -11,14 +11,24 @@ public class CraftingListener implements Listener {
     @EventHandler
     public void stoneRecipeOverrides(PrepareItemCraftEvent event) {
         ItemStack[] craftingGridItemStacks = event.getInventory().getMatrix();
-        Material[] craftingGrid = new Material[9];
+        Material[] craftingGrid = new Material[craftingGridItemStacks.length];
 
-        for (int a = 0; a <= 8; a++) {
+        for (int a = 0; a < craftingGridItemStacks.length; a++) {
             if (craftingGridItemStacks[a] != null) {
                 craftingGrid[a] = craftingGridItemStacks[a].getType();
             }
         }
 
+        if (event.getInventory().getType() == InventoryType.WORKBENCH) {
+            craftingTableStoneRecipeOverrides(event, craftingGrid);
+
+            return;
+        }
+
+        playerCraftingStoneRecipeOverrides(event, craftingGrid);
+    }
+
+    public void craftingTableStoneRecipeOverrides(PrepareItemCraftEvent event, Material[] craftingGrid) {
         if (furnaceOverride(craftingGrid)) {
             event.getInventory().setResult(new ItemStack(Material.FURNACE));
 
@@ -61,7 +71,13 @@ public class CraftingListener implements Listener {
             return;
         }
 
-        if (polishedDeepslateOverride(craftingGrid)) {
+        if (polishedDeepslateCraftingTableOverride(craftingGrid)) {
+            event.getInventory().setResult(new ItemStack(Material.POLISHED_DEEPSLATE, 4));
+        }
+    }
+
+    public void playerCraftingStoneRecipeOverrides(PrepareItemCraftEvent event, Material[] craftingGrid) {
+        if (polishedDeepslatePlayerCraftingOverride(craftingGrid)) {
             event.getInventory().setResult(new ItemStack(Material.POLISHED_DEEPSLATE, 4));
         }
     }
@@ -89,11 +105,11 @@ public class CraftingListener implements Listener {
         Material[] slabRecipe2 = new Material[]{null, null, null, material, material, material, null, null, null};
         Material[] slabRecipe3 = new Material[]{null, null, null, null, null, null, material, material, material};
 
-        if (recipeCheck(craftingGrid, slabRecipe1)) return true;
+        if (recipeCheck(craftingGrid, slabRecipe1, true)) return true;
 
-        if (recipeCheck(craftingGrid, slabRecipe2)) return true;
+        if (recipeCheck(craftingGrid, slabRecipe2, true)) return true;
 
-        return recipeCheck(craftingGrid, slabRecipe3);
+        return recipeCheck(craftingGrid, slabRecipe3, true);
     }
 
     public boolean wallOverride(Material[] craftingGrid, Material material) {
@@ -102,9 +118,9 @@ public class CraftingListener implements Listener {
         Material[] wallRecipe2 = new Material[]{null, null, null, material, material, material,
             material, material, material};
 
-        if (recipeCheck(craftingGrid, wallRecipe1)) return true;
+        if (recipeCheck(craftingGrid, wallRecipe1, true)) return true;
 
-        return recipeCheck(craftingGrid, wallRecipe2);
+        return recipeCheck(craftingGrid, wallRecipe2, true);
     }
 
     public boolean stairOverride(Material[] craftingGrid, Material material) {
@@ -113,34 +129,43 @@ public class CraftingListener implements Listener {
         Material[] stairRecipe2 = new Material[]{null, null, material, null, material, material,
             material, material, material};
 
-        if (recipeCheck(craftingGrid, stairRecipe1)) return true;
+        if (recipeCheck(craftingGrid, stairRecipe1, true)) return true;
 
-        return recipeCheck(craftingGrid, stairRecipe2);
+        return recipeCheck(craftingGrid, stairRecipe2, true);
     }
 
-    public boolean polishedDeepslateOverride(Material[] craftingGrid) {
-        Material material = Material.COBBLED_DEEPSLATE;
+    public boolean polishedDeepslateCraftingTableOverride(Material[] craftingGrid) {
+        Material[] polishedDeepslateRecipe1 = new Material[]{Material.COBBLED_DEEPSLATE, Material.COBBLED_DEEPSLATE,
+            null, Material.COBBLED_DEEPSLATE, Material.COBBLED_DEEPSLATE, null, null, null, null};
+        Material[] polishedDeepslateRecipe2 = new Material[]{null, Material.COBBLED_DEEPSLATE,
+            Material.COBBLED_DEEPSLATE, null, Material.COBBLED_DEEPSLATE, Material.COBBLED_DEEPSLATE, null, null, null};
+        Material[] polishedDeepslateRecipe3 = new Material[]{null, null, null, Material.COBBLED_DEEPSLATE,
+            Material.COBBLED_DEEPSLATE, null, Material.COBBLED_DEEPSLATE, Material.COBBLED_DEEPSLATE, null};
+        Material[] polishedDeepslateRecipe4 = new Material[]{null, null, null, null, Material.COBBLED_DEEPSLATE,
+            Material.COBBLED_DEEPSLATE, null, Material.COBBLED_DEEPSLATE, Material.COBBLED_DEEPSLATE};
 
-        Material[] polishedDeepslateRecipe1 = new Material[]{material, material, null, material, material, null,
-        null, null, null};
-        Material[] polishedDeepslateRecipe2 = new Material[]{null, material, material, null, material, material,
-        null, null, null};
-        Material[] polishedDeepslateRecipe3 = new Material[]{null, null, null, material, material, null,
-        material, material, null};
-        Material[] polishedDeepslateRecipe4 = new Material[]{null, null, null, null, material, material,
-        null, material, material};
+        if (recipeCheck(craftingGrid, polishedDeepslateRecipe1, true)) return true;
 
-        if (recipeCheck(craftingGrid, polishedDeepslateRecipe1)) return true;
+        if (recipeCheck(craftingGrid, polishedDeepslateRecipe2, true)) return true;
 
-        if (recipeCheck(craftingGrid, polishedDeepslateRecipe2)) return true;
+        if (recipeCheck(craftingGrid, polishedDeepslateRecipe3, true)) return true;
 
-        if (recipeCheck(craftingGrid, polishedDeepslateRecipe3)) return true;
-
-        return recipeCheck(craftingGrid, polishedDeepslateRecipe4);
+        return recipeCheck(craftingGrid, polishedDeepslateRecipe4, true);
     }
 
-    public boolean recipeCheck(Material[] craftingGrid, Material[] recipe) {
-        for (int a = 0; a <= 8; a++) {
+    public boolean polishedDeepslatePlayerCraftingOverride(Material[] craftingGrid) {
+        return recipeCheck(craftingGrid, new Material[]{Material.COBBLED_DEEPSLATE, Material.COBBLED_DEEPSLATE,
+            Material.COBBLED_DEEPSLATE, Material.COBBLED_DEEPSLATE}, false);
+    }
+
+    public boolean recipeCheck(Material[] craftingGrid, Material[] recipe, boolean craftingTable) {
+        int slots;
+
+        if (craftingTable) slots = 9;
+
+        else slots = 4;
+
+        for (int a = 0; a < slots; a++) {
             if (craftingGrid[a] != recipe[a]) return false;
         }
 

--- a/src/main/java/me/ShermansWorld/AlathraExtras/crafting/CraftingListener.java
+++ b/src/main/java/me/ShermansWorld/AlathraExtras/crafting/CraftingListener.java
@@ -16,6 +16,8 @@ public class CraftingListener implements Listener {
         for (int a = 0; a <= 8; a++) {
             if (a == 4) continue;
 
+            if (craftingGrid[a] == null) return;
+
             if (craftingGrid[a].getType() != Material.COBBLESTONE) return;
         }
 

--- a/src/main/java/me/ShermansWorld/AlathraExtras/crafting/CraftingRecipes.java
+++ b/src/main/java/me/ShermansWorld/AlathraExtras/crafting/CraftingRecipes.java
@@ -7,191 +7,177 @@ import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
 import org.bukkit.inventory.*;
 import org.bukkit.inventory.meta.ItemMeta;
-import org.bukkit.plugin.Plugin;
 
 public class CraftingRecipes {
-
-    public void saddleRecipe() {
+    public static void saddleRecipe() {
         ItemStack saddle = new ItemStack(Material.SADDLE, 1);
-        NamespacedKey key = new NamespacedKey((Plugin) AlathraExtras.getInstance(),
-            String.valueOf(AlathraExtras.getInstance().getDescription().getName()) + "2");
+        NamespacedKey key = new NamespacedKey(AlathraExtras.getInstance(),
+            AlathraExtras.getInstance().getName() + "saddleRecipe");
         ShapedRecipe saddleRecipe = new ShapedRecipe(key, saddle);
-        saddleRecipe.shape(new String[]{"%%%", "@ @"});
+        saddleRecipe.shape("%%%", "@ @");
         saddleRecipe.setIngredient('@', Material.TRIPWIRE_HOOK);
         saddleRecipe.setIngredient('%', Material.LEATHER);
-        AlathraExtras.getInstance().getServer().addRecipe((Recipe) saddleRecipe);
+        AlathraExtras.getInstance().getServer().addRecipe(saddleRecipe);
     }
 
-    public void charcoalBlock() {
+    public static void charcoalBlock() {
         ItemStack charcoalBlock = new ItemStack(Material.COAL_BLOCK, 1);
         ItemMeta meta = charcoalBlock.getItemMeta();
         meta.setDisplayName(Helper.color("&8Block of Charcoal"));
         charcoalBlock.setItemMeta(meta);
-        NamespacedKey key = new NamespacedKey((Plugin) AlathraExtras.getInstance(),
-            String.valueOf(AlathraExtras.getInstance().getDescription().getName()) + "3");
-        ShapedRecipe charcoalBlockRecipe = new ShapedRecipe(key, charcoalBlock);
-        charcoalBlockRecipe.shape(new String[]{"@@@", "@@@", "@@@"});
-        charcoalBlockRecipe.setIngredient('@', Material.CHARCOAL);
-        AlathraExtras.getInstance().getServer().addRecipe((Recipe) charcoalBlockRecipe);
+        NamespacedKey key = new NamespacedKey(AlathraExtras.getInstance(),
+            AlathraExtras.getInstance().getName() + "charcoalBlock");
+        ShapelessRecipe charcoalBlockRecipe = new ShapelessRecipe(key, charcoalBlock);
+        charcoalBlockRecipe.addIngredient(9, Material.CHARCOAL);
+        AlathraExtras.getInstance().getServer().addRecipe(charcoalBlockRecipe);
     }
 
-    public void redDyeRecipe() {
+    public static void redDyeRecipe() {
         ItemStack redDye = new ItemStack(Material.RED_DYE, 1);
-        NamespacedKey key = new NamespacedKey((Plugin) AlathraExtras.getInstance(),
-            String.valueOf(AlathraExtras.getInstance().getDescription().getName()) + "4");
+        NamespacedKey key = new NamespacedKey(AlathraExtras.getInstance(),
+            AlathraExtras.getInstance().getName() + "redDyeRecipe");
         ShapelessRecipe redDyeRecipe = new ShapelessRecipe(key, redDye);
         redDyeRecipe.addIngredient(1, Material.REDSTONE);
-        AlathraExtras.getInstance().getServer().addRecipe((Recipe) redDyeRecipe);
+        AlathraExtras.getInstance().getServer().addRecipe(redDyeRecipe);
     }
 
-    public void redSandRecipe() {
+    public static void redSandRecipe() {
         ItemStack redSand = new ItemStack(Material.RED_SAND, 8);
-        NamespacedKey key = new NamespacedKey((Plugin) AlathraExtras.getInstance(),
-            String.valueOf(AlathraExtras.getInstance().getDescription().getName()) + "5");
-        ShapedRecipe redSandRecipe = new ShapedRecipe(key, redSand);
-        redSandRecipe.shape(new String[]{"@@@", "@%@", "@@@"});
-        redSandRecipe.setIngredient('@', Material.SAND);
-        redSandRecipe.setIngredient('%', Material.RED_DYE);
-        AlathraExtras.getInstance().getServer().addRecipe((Recipe) redSandRecipe);
+        NamespacedKey key = new NamespacedKey(AlathraExtras.getInstance(),
+            AlathraExtras.getInstance().getName() + "redSandRecipe");
+        ShapelessRecipe redSandRecipe = new ShapelessRecipe(key, redSand);
+        redSandRecipe.addIngredient(8, Material.SAND);
+        redSandRecipe.addIngredient(1, Material.RED_DYE);
+        AlathraExtras.getInstance().getServer().addRecipe(redSandRecipe);
     }
 
-    public void bellRecipe() {
+    public static void bellRecipe() {
         ItemStack bell = new ItemStack(Material.BELL, 1);
-        NamespacedKey key = new NamespacedKey((Plugin) AlathraExtras.getInstance(),
-            String.valueOf(AlathraExtras.getInstance().getDescription().getName()) + "6");
+        NamespacedKey key = new NamespacedKey(AlathraExtras.getInstance(),
+            AlathraExtras.getInstance().getName() + "bellRecipe");
         ShapedRecipe bellRecipe = new ShapedRecipe(key, bell);
-        bellRecipe.shape(new String[]{" @ ", "@%@"});
+        bellRecipe.shape(" @ ", "@%@");
         bellRecipe.setIngredient('@', Material.GOLD_BLOCK);
         bellRecipe.setIngredient('%', Material.GOLD_INGOT);
-        AlathraExtras.getInstance().getServer().addRecipe((Recipe) bellRecipe);
+        AlathraExtras.getInstance().getServer().addRecipe(bellRecipe);
     }
 
-    public void blackDyeRecipe1() {
-        ItemStack blackDye1 = new ItemStack(Material.BLACK_DYE, 1);
-        NamespacedKey key = new NamespacedKey((Plugin) AlathraExtras.getInstance(),
-            String.valueOf(AlathraExtras.getInstance().getDescription().getName()) + "7");
-        ShapelessRecipe blackDyeRecipe1 = new ShapelessRecipe(key, blackDye1);
-        blackDyeRecipe1.addIngredient(1, Material.COAL);
-        AlathraExtras.getInstance().getServer().addRecipe((Recipe) blackDyeRecipe1);
+    public static void blackDyeRecipe() {
+        ItemStack blackDye = new ItemStack(Material.BLACK_DYE, 1);
+        NamespacedKey key = new NamespacedKey(AlathraExtras.getInstance(),
+            AlathraExtras.getInstance().getName() + "blackDyeRecipe");
+        RecipeChoice.MaterialChoice input = new RecipeChoice.MaterialChoice(Material.COAL, Material.CHARCOAL);
+        ShapelessRecipe blackDyeRecipe = new ShapelessRecipe(key, blackDye);
+        blackDyeRecipe.addIngredient(input);
+        AlathraExtras.getInstance().getServer().addRecipe(blackDyeRecipe);
     }
 
-    public void blackDyeRecipe2() {
-        ItemStack blackDye2 = new ItemStack(Material.BLACK_DYE, 1);
-        NamespacedKey key = new NamespacedKey((Plugin) AlathraExtras.getInstance(),
-            String.valueOf(AlathraExtras.getInstance().getDescription().getName()) + "8");
-        ShapelessRecipe blackDyeRecipe2 = new ShapelessRecipe(key, blackDye2);
-        blackDyeRecipe2.addIngredient(1, Material.CHARCOAL);
-        AlathraExtras.getInstance().getServer().addRecipe((Recipe) blackDyeRecipe2);
-    }
-
-    public void beetRootPouchRecipe() {
+    public static void beetrootPouchRecipe() {
         ItemStack beetRootPouch = CustomItems.getBeetrootPouch();
-        NamespacedKey key = new NamespacedKey((Plugin) AlathraExtras.getInstance(),
-            String.valueOf(AlathraExtras.getInstance().getDescription().getName()) + "9");
-        ShapedRecipe beetRootPouchRecipe = new ShapedRecipe(key, beetRootPouch);
-        beetRootPouchRecipe.shape(new String[]{"@@@", "@@@", "@@@"});
-        beetRootPouchRecipe.setIngredient('@', Material.BEETROOT);
-        AlathraExtras.getInstance().getServer().addRecipe((Recipe) beetRootPouchRecipe);
+        NamespacedKey key = new NamespacedKey(AlathraExtras.getInstance(),
+            AlathraExtras.getInstance().getName() + "beetrootPouchRecipe");
+        ShapelessRecipe beetrootPouchRecipe = new ShapelessRecipe(key, beetRootPouch);
+        beetrootPouchRecipe.addIngredient(9, Material.BEETROOT);
+        AlathraExtras.getInstance().getServer().addRecipe(beetrootPouchRecipe);
     }
 
-    public void carrotPouchRecipe() {
+    public static void carrotPouchRecipe() {
         ItemStack carrotPouch = CustomItems.getCarrotPouch();
-        NamespacedKey key = new NamespacedKey((Plugin) AlathraExtras.getInstance(),
-            String.valueOf(AlathraExtras.getInstance().getDescription().getName()) + "10");
-        ShapedRecipe CarrotPouchRecipe = new ShapedRecipe(key, carrotPouch);
-        CarrotPouchRecipe.shape(new String[]{"@@@", "@@@", "@@@"});
-        CarrotPouchRecipe.setIngredient('@', Material.CARROT);
-        AlathraExtras.getInstance().getServer().addRecipe((Recipe) CarrotPouchRecipe);
+        NamespacedKey key = new NamespacedKey(AlathraExtras.getInstance(),
+            AlathraExtras.getInstance().getName() + "carrotPouchRecipe");
+        ShapelessRecipe carrotPouchRecipe = new ShapelessRecipe(key, carrotPouch);
+        carrotPouchRecipe.addIngredient(9, Material.CARROT);
+        AlathraExtras.getInstance().getServer().addRecipe(carrotPouchRecipe);
     }
 
-    public void potatoPouchRecipe() {
+    public static void potatoPouchRecipe() {
         ItemStack potatoPouch = CustomItems.getPotatoPouch();
-        NamespacedKey key = new NamespacedKey((Plugin) AlathraExtras.getInstance(),
-            String.valueOf(AlathraExtras.getInstance().getDescription().getName()) + "11");
-        ShapedRecipe PotatoPouchRecipe = new ShapedRecipe(key, potatoPouch);
-        PotatoPouchRecipe.shape(new String[]{"@@@", "@@@", "@@@"});
-        PotatoPouchRecipe.setIngredient('@', Material.POTATO);
-        AlathraExtras.getInstance().getServer().addRecipe((Recipe) PotatoPouchRecipe);
+        NamespacedKey key = new NamespacedKey(AlathraExtras.getInstance(),
+            AlathraExtras.getInstance().getName() + "potatoPouchRecipe");
+        ShapelessRecipe potatoPouchRecipe = new ShapelessRecipe(key, potatoPouch);
+        potatoPouchRecipe.addIngredient(9, Material.POTATO);
+        AlathraExtras.getInstance().getServer().addRecipe(potatoPouchRecipe);
     }
 
-    public void dioriteRecipe1() {
+    public static void dioriteRecipe1() {
         ItemStack diorite1 = new ItemStack(Material.DIORITE, 2);
-        NamespacedKey key = new NamespacedKey((Plugin) AlathraExtras.getInstance(),
-            String.valueOf(AlathraExtras.getInstance().getDescription().getName()) + "12");
+        NamespacedKey key = new NamespacedKey(AlathraExtras.getInstance(),
+            AlathraExtras.getInstance().getName() + "dioriteRecipe1");
         ShapelessRecipe dioriteRecipe1 = new ShapelessRecipe(key, diorite1);
         dioriteRecipe1.addIngredient(2, Material.ANDESITE);
         dioriteRecipe1.addIngredient(1, Material.QUARTZ);
-        AlathraExtras.getInstance().getServer().addRecipe((Recipe) dioriteRecipe1);
+        AlathraExtras.getInstance().getServer().addRecipe(dioriteRecipe1);
     }
 
-    public void dioriteRecipe2() {
+    public static void dioriteRecipe2() {
         ItemStack diorite2 = new ItemStack(Material.DIORITE, 2);
-        NamespacedKey key = new NamespacedKey((Plugin) AlathraExtras.getInstance(),
-            String.valueOf(AlathraExtras.getInstance().getDescription().getName()) + "13");
+        NamespacedKey key = new NamespacedKey(AlathraExtras.getInstance(),
+            AlathraExtras.getInstance().getName() + "dioriteRecipe2");
         ShapelessRecipe dioriteRecipe2 = new ShapelessRecipe(key, diorite2);
         dioriteRecipe2.addIngredient(1, Material.GRANITE);
         dioriteRecipe2.addIngredient(1, Material.COBBLESTONE);
-        AlathraExtras.getInstance().getServer().addRecipe((Recipe) dioriteRecipe2);
+        AlathraExtras.getInstance().getServer().addRecipe(dioriteRecipe2);
     }
 
-    public void dioriteRecipe3() {
+    public static void dioriteRecipe3() {
         ItemStack diorite3 = new ItemStack(Material.DIORITE, 3);
-        NamespacedKey key = new NamespacedKey((Plugin) AlathraExtras.getInstance(),
-            String.valueOf(AlathraExtras.getInstance().getDescription().getName()) + "14");
+        NamespacedKey key = new NamespacedKey(AlathraExtras.getInstance(),
+            AlathraExtras.getInstance().getName() + "dioriteRecipe3");
         ShapelessRecipe dioriteRecipe3 = new ShapelessRecipe(key, diorite3);
         dioriteRecipe3.addIngredient(2, Material.ANDESITE);
         dioriteRecipe3.addIngredient(1, Material.GRANITE);
-        AlathraExtras.getInstance().getServer().addRecipe((Recipe) dioriteRecipe3);
+        AlathraExtras.getInstance().getServer().addRecipe(dioriteRecipe3);
     }
 
-    public void greenDyeRecipe() {
+    public static void greenDyeRecipe() {
         ItemStack greenDye = new ItemStack(Material.GREEN_DYE, 2);
-        NamespacedKey key = new NamespacedKey((Plugin) AlathraExtras.getInstance(),
-            String.valueOf(AlathraExtras.getInstance().getDescription().getName()) + "16");
+        NamespacedKey key = new NamespacedKey(AlathraExtras.getInstance(),
+            AlathraExtras.getInstance().getName() + "greenDyeRecipe");
         ShapelessRecipe greenDyeRecipe = new ShapelessRecipe(key, greenDye);
         greenDyeRecipe.addIngredient(1, Material.BLUE_DYE);
         greenDyeRecipe.addIngredient(1, Material.YELLOW_DYE);
-        AlathraExtras.getInstance().getServer().addRecipe((Recipe) greenDyeRecipe);
+        AlathraExtras.getInstance().getServer().addRecipe(greenDyeRecipe);
     }
 
-    public void pinkPetalsRecipe() {
+    public static void pinkPetalsRecipe() {
         ItemStack pinkPetals = new ItemStack(Material.PINK_PETALS, 1);
-        NamespacedKey key = new NamespacedKey((Plugin) AlathraExtras.getInstance(),
-            String.valueOf(AlathraExtras.getInstance().getDescription().getName()) + "17");
+        NamespacedKey key = new NamespacedKey(AlathraExtras.getInstance(),
+            AlathraExtras.getInstance().getName() + "pinkPetalsRecipe");
         ShapelessRecipe pinkPetalsRecipe = new ShapelessRecipe(key, pinkPetals);
         pinkPetalsRecipe.addIngredient(1, Material.CHERRY_LEAVES);
-        AlathraExtras.getInstance().getServer().addRecipe((Recipe) pinkPetalsRecipe);
+        AlathraExtras.getInstance().getServer().addRecipe(pinkPetalsRecipe);
     }
 
-    public void stonesToGravel() {
+    public static void stonesToGravel(int a) {
+        for (int b = 0; b <= a; b++) {
+            NamespacedKey key = new NamespacedKey(AlathraExtras.getInstance(),
+                AlathraExtras.getInstance().getName() + "stonesToGravela" + a + "b" + b);
+            ItemStack result = new ItemStack(Material.GRAVEL, a);
+
+            ShapelessRecipe recipe = new ShapelessRecipe(key, result);
+
+            recipe.addIngredient(a - b, Material.COBBLESTONE);
+            recipe.addIngredient(b, Material.COBBLED_DEEPSLATE);
+
+            AlathraExtras.getInstance().getServer().addRecipe(recipe);
+        }
+    }
+
+    public static void gravelToSand(int a) {
         NamespacedKey key = new NamespacedKey(AlathraExtras.getInstance(),
-            String.valueOf(AlathraExtras.getInstance().getDescription().getName()) + "18");
-        RecipeChoice.MaterialChoice input = new RecipeChoice.MaterialChoice(Material.COBBLESTONE, Material.COBBLED_DEEPSLATE);
-        ItemStack result = new ItemStack(Material.GRAVEL, 1);
+            AlathraExtras.getInstance().getName() + "gravelToSand" + a);
+        ItemStack result = new ItemStack(Material.SAND, a);
 
         ShapelessRecipe recipe = new ShapelessRecipe(key, result);
 
-        recipe.addIngredient(input);
+        recipe.addIngredient(a, Material.GRAVEL);
 
         AlathraExtras.getInstance().getServer().addRecipe(recipe);
     }
 
-    public void gravelToSand() {
+    public static void dioriteToQuartz() {
         NamespacedKey key = new NamespacedKey(AlathraExtras.getInstance(),
-            String.valueOf(AlathraExtras.getInstance().getDescription().getName()) + "19");
-        RecipeChoice.MaterialChoice input = new RecipeChoice.MaterialChoice(Material.GRAVEL);
-        ItemStack result = new ItemStack(Material.SAND, 1);
-
-        ShapelessRecipe recipe = new ShapelessRecipe(key, result);
-
-        recipe.addIngredient(input);
-
-        AlathraExtras.getInstance().getServer().addRecipe(recipe);
-    }
-
-    public void dioriteToQuartz() {
-        NamespacedKey key = new NamespacedKey(AlathraExtras.getInstance(),
-            String.valueOf(AlathraExtras.getInstance().getDescription().getName()) + "20");
+            AlathraExtras.getInstance().getName() + "dioriteToQuartz");
         RecipeChoice.MaterialChoice input = new RecipeChoice.MaterialChoice(Material.DIORITE);
         ItemStack result = new ItemStack(Material.QUARTZ, 1);
 
@@ -202,22 +188,21 @@ public class CraftingRecipes {
         AlathraExtras.getInstance().getServer().addRecipe(recipe);
     }
 
-    public void coarseDirtToDirt() {
+    public static void coarseDirtToDirt(int a) {
         NamespacedKey key = new NamespacedKey(AlathraExtras.getInstance(),
-            String.valueOf(AlathraExtras.getInstance().getDescription().getName()) + "21");
-        RecipeChoice.MaterialChoice input = new RecipeChoice.MaterialChoice(Material.COARSE_DIRT);
-        ItemStack result = new ItemStack(Material.DIRT, 1);
+            AlathraExtras.getInstance().getName() + "coarseDirtToDirt" + a);
+        ItemStack result = new ItemStack(Material.DIRT, a);
 
         ShapelessRecipe recipe = new ShapelessRecipe(key, result);
 
-        recipe.addIngredient(input);
+        recipe.addIngredient(a, Material.COARSE_DIRT);
 
         AlathraExtras.getInstance().getServer().addRecipe(recipe);
     }
 
-    public void beetrootPouchToBeetroot() {
+    public static void beetrootPouchToBeetroots() {
         NamespacedKey key = new NamespacedKey(AlathraExtras.getInstance(),
-            String.valueOf(AlathraExtras.getInstance().getDescription().getName()) + "22");
+            AlathraExtras.getInstance().getName() + "beetrootPouchToBeetroots");
         RecipeChoice.ExactChoice input = new RecipeChoice.ExactChoice(CustomItems.getBeetrootPouch());
         ItemStack result = new ItemStack(Material.BEETROOT, 9);
 
@@ -228,9 +213,9 @@ public class CraftingRecipes {
         AlathraExtras.getInstance().getServer().addRecipe(recipe);
     }
 
-    public void carrotPouchToCarrot() {
+    public static void carrotPouchToCarrots() {
         NamespacedKey key = new NamespacedKey(AlathraExtras.getInstance(),
-            String.valueOf(AlathraExtras.getInstance().getDescription().getName()) + "23");
+            AlathraExtras.getInstance().getName() + "carrotPouchToCarrots");
         RecipeChoice.ExactChoice input = new RecipeChoice.ExactChoice(CustomItems.getCarrotPouch());
         ItemStack result = new ItemStack(Material.CARROT, 9);
 
@@ -241,9 +226,9 @@ public class CraftingRecipes {
         AlathraExtras.getInstance().getServer().addRecipe(recipe);
     }
 
-    public void potatoPouchToPotato() {
+    public static void potatoPouchToPotatos() {
         NamespacedKey key = new NamespacedKey(AlathraExtras.getInstance(),
-            String.valueOf(AlathraExtras.getInstance().getDescription().getName()) + "24");
+            AlathraExtras.getInstance().getName() + "potatoPouchToPotatos");
         RecipeChoice.ExactChoice input = new RecipeChoice.ExactChoice(CustomItems.getPotatoPouch());
         ItemStack result = new ItemStack(Material.POTATO, 9);
 
@@ -252,5 +237,36 @@ public class CraftingRecipes {
         recipe.addIngredient(input);
 
         AlathraExtras.getInstance().getServer().addRecipe(recipe);
+    }
+
+    public static void allMultiBlockRecipes() {
+        for (int a = 1; a <= 9; a++) {
+            stonesToGravel(a);
+            gravelToSand(a);
+            coarseDirtToDirt(a);
+        }
+    }
+
+    public static void registerAllCraftingRecipes() {
+        saddleRecipe();
+        charcoalBlock();
+        redDyeRecipe();
+        redSandRecipe();
+        bellRecipe();
+        blackDyeRecipe();
+        beetrootPouchRecipe();
+        carrotPouchRecipe();
+        potatoPouchRecipe();
+        dioriteRecipe1();
+        dioriteRecipe2();
+        dioriteRecipe3();
+        greenDyeRecipe();
+        pinkPetalsRecipe();
+        dioriteToQuartz();
+        beetrootPouchToBeetroots();
+        carrotPouchToCarrots();
+        potatoPouchToPotatos();
+
+        allMultiBlockRecipes();
     }
 }

--- a/src/main/java/me/ShermansWorld/AlathraExtras/crafting/CraftingRecipes.java
+++ b/src/main/java/me/ShermansWorld/AlathraExtras/crafting/CraftingRecipes.java
@@ -282,7 +282,7 @@ public class CraftingRecipes {
         beetrootPouchToBeetroots();
         carrotPouchToCarrots();
         potatoPouchToPotatos();
-        cryingObsidianRecipe()
+        cryingObsidianRecipe();
         allMultiBlockRecipes();
     }
 }

--- a/src/main/java/me/ShermansWorld/AlathraExtras/misc/PaperRecipesListener.java
+++ b/src/main/java/me/ShermansWorld/AlathraExtras/misc/PaperRecipesListener.java
@@ -9,7 +9,7 @@ import org.bukkit.inventory.ItemStack;
 
 import java.util.Arrays;
 
-public class CraftingListener implements Listener {
+public class PaperRecipesListener implements Listener {
     @EventHandler
     public void craftEvent(CraftItemEvent e) {
         if (Arrays.asList(e.getInventory().getStorageContents()).contains(CustomItems.tutorialBook())) {


### PR DESCRIPTION
Added convenience recipes, cleaned existing crafting recipes code, and bumped RunServer Minecraft version from 1.20.1 to 1.20.4 to match the server (bump to 1.20.0, which I put live to the server).
Fixed furnace recipes by adding a listener to override the convenience recipes (bump to 1.20.1, which also got put live to the server).
Fixed console spam from v1.20.1 no having proper null safety checks and corrected all other vanilla recipes influenced by these v1.20.0's changes (bump to 1.20.2, which also got put live to the server).
Fixed recipes and console spam for player inventory crafting grid. Final version bump to 1.20.3 (will be put on the server during evening restart (EST) 01-13-2023.

All of the above have been gameplay tested to work correctly.