### PR TITLE
Fix/disable trapdoor flipping in spawn

### DIFF
--- a/src/main/java/me/ShermansWorld/AlathraExtras/AlathraExtras.java
+++ b/src/main/java/me/ShermansWorld/AlathraExtras/AlathraExtras.java
@@ -7,6 +7,7 @@ import me.ShermansWorld.AlathraExtras.chatitem.ShowItemCommand;
 import me.ShermansWorld.AlathraExtras.crafting.*;
 import me.ShermansWorld.AlathraExtras.disabledispensereggs.DispenserListener;
 import me.ShermansWorld.AlathraExtras.disablespawners.DisableSpawners;
+import me.ShermansWorld.AlathraExtras.disabletrapdoorflipping.TrapdoorListener;
 import me.ShermansWorld.AlathraExtras.enderchersblock.EnderChestBlockListener;
 import me.ShermansWorld.AlathraExtras.endermanexp.EndermanExpDropListener;
 import me.ShermansWorld.AlathraExtras.funny.AetherPortalListener;
@@ -155,6 +156,7 @@ public class AlathraExtras extends JavaPlugin {
         this.getServer().getPluginManager().registerEvents(new VotingListener(), this);
         this.getServer().getPluginManager().registerEvents(new DispenserListener(), this);
         this.getServer().getPluginManager().registerEvents(new NPCListener(), this);
+        this.getServer().getPluginManager().registerEvents(new TrapdoorListener(), this);
 
         initRecipeItems();
         FurnaceRecipes furnaceRecipes = new FurnaceRecipes();

--- a/src/main/java/me/ShermansWorld/AlathraExtras/disabletrapdoorflipping/TrapdoorListener.java
+++ b/src/main/java/me/ShermansWorld/AlathraExtras/disabletrapdoorflipping/TrapdoorListener.java
@@ -1,6 +1,7 @@
 package me.ShermansWorld.AlathraExtras.disabletrapdoorflipping;
 
 import com.destroystokyo.paper.MaterialTags;
+import org.bukkit.GameMode;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.Action;
@@ -22,6 +23,7 @@ public class TrapdoorListener implements Listener {
             && e.getClickedBlock() != null
             && (MaterialTags.TRAPDOORS.isTagged(e.getClickedBlock().getType())
             && e.getClickedBlock().getWorld().getName().equals("world")
+            && e.getPlayer().getGameMode() != GameMode.CREATIVE
         )) // If so, cancel the interaction.
         {
             e.setCancelled(true);

--- a/src/main/java/me/ShermansWorld/AlathraExtras/disabletrapdoorflipping/TrapdoorListener.java
+++ b/src/main/java/me/ShermansWorld/AlathraExtras/disabletrapdoorflipping/TrapdoorListener.java
@@ -6,7 +6,15 @@ import org.bukkit.event.Listener;
 import org.bukkit.event.block.Action;
 import org.bukkit.event.player.PlayerInteractEvent;
 
+/**
+ * Listens for trapdoor interaction events
+ */
 public class TrapdoorListener implements Listener {
+
+    /**
+     * Checks for player interactions with a trapdoor.
+     * @param e the player interaction event
+     */
     @EventHandler
     public void onInteract(PlayerInteractEvent e) {
         // Checks if the action is right click, and the right click is at a block.

--- a/src/main/java/me/ShermansWorld/AlathraExtras/disabletrapdoorflipping/TrapdoorListener.java
+++ b/src/main/java/me/ShermansWorld/AlathraExtras/disabletrapdoorflipping/TrapdoorListener.java
@@ -27,7 +27,6 @@ public class TrapdoorListener implements Listener {
             && e.getPlayer().getGameMode() != GameMode.CREATIVE
         ) // If so, cancel the interaction.
         {
-            AlathraExtras.logger.log("Test log.");
             e.setCancelled(true);
         }
     }

--- a/src/main/java/me/ShermansWorld/AlathraExtras/disabletrapdoorflipping/TrapdoorListener.java
+++ b/src/main/java/me/ShermansWorld/AlathraExtras/disabletrapdoorflipping/TrapdoorListener.java
@@ -1,0 +1,22 @@
+package me.ShermansWorld.AlathraExtras.disabletrapdoorflipping;
+
+import com.destroystokyo.paper.MaterialTags;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.block.Action;
+import org.bukkit.event.player.PlayerInteractEvent;
+
+public class TrapdoorListener implements Listener {
+    @EventHandler
+    public void onInteract(PlayerInteractEvent e) {
+        // Checks if the action is right click, and the right click is at a block.
+        if(e.getAction() == Action.RIGHT_CLICK_BLOCK
+            && e.getClickedBlock() != null
+            && (MaterialTags.TRAPDOORS.isTagged(e.getClickedBlock().getType())
+            && e.getClickedBlock().getWorld().getName().equals("world")
+        )) // If so, cancel the interaction.
+        {
+            e.setCancelled(true);
+        }
+    }
+}

--- a/src/main/java/me/ShermansWorld/AlathraExtras/disabletrapdoorflipping/TrapdoorListener.java
+++ b/src/main/java/me/ShermansWorld/AlathraExtras/disabletrapdoorflipping/TrapdoorListener.java
@@ -1,6 +1,7 @@
 package me.ShermansWorld.AlathraExtras.disabletrapdoorflipping;
 
 import com.destroystokyo.paper.MaterialTags;
+import me.ShermansWorld.AlathraExtras.AlathraExtras;
 import org.bukkit.GameMode;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
@@ -21,11 +22,12 @@ public class TrapdoorListener implements Listener {
         // Checks if the action is right click, and the right click is at a block.
         if(e.getAction() == Action.RIGHT_CLICK_BLOCK
             && e.getClickedBlock() != null
-            && (MaterialTags.TRAPDOORS.isTagged(e.getClickedBlock().getType())
+            && e.getClickedBlock().getType().toString().toLowerCase().contains("trapdoor")
             && e.getClickedBlock().getWorld().getName().equals("world")
             && e.getPlayer().getGameMode() != GameMode.CREATIVE
-        )) // If so, cancel the interaction.
+        ) // If so, cancel the interaction.
         {
+            AlathraExtras.logger.log("Test log.");
             e.setCancelled(true);
         }
     }

--- a/src/main/java/me/ShermansWorld/AlathraExtras/disabletrapdoorflipping/TrapdoorListener.java
+++ b/src/main/java/me/ShermansWorld/AlathraExtras/disabletrapdoorflipping/TrapdoorListener.java
@@ -22,7 +22,7 @@ public class TrapdoorListener implements Listener {
         // Checks if the action is right click, and the right click is at a block.
         if(e.getAction() == Action.RIGHT_CLICK_BLOCK
             && e.getClickedBlock() != null
-            && e.getClickedBlock().getType().toString().toLowerCase().contains("trapdoor")
+            && MaterialTags.TRAPDOORS.isTagged(e.getClickedBlock().getType())
             && e.getClickedBlock().getWorld().getName().equals("world")
             && e.getPlayer().getGameMode() != GameMode.CREATIVE
         ) // If so, cancel the interaction.


### PR DESCRIPTION
This should fix the problem where players could flip trapdoors causing the spawn to look bad.