### PR TITLE
feat: inactive residents added to Towny Menu

### DIFF
--- a/src/main/java/me/ShermansWorld/AlathraExtras/AlathraExtras.java
+++ b/src/main/java/me/ShermansWorld/AlathraExtras/AlathraExtras.java
@@ -31,6 +31,7 @@ import me.ShermansWorld.AlathraExtras.puke.PukeCommand;
 import me.ShermansWorld.AlathraExtras.repair.RepairListener;
 import me.ShermansWorld.AlathraExtras.roll.RollCommand;
 import me.ShermansWorld.AlathraExtras.towny.TownyListener;
+import me.ShermansWorld.AlathraExtras.towny.TownyMenu;
 import me.ShermansWorld.AlathraExtras.tpacooldown.CooldownManager;
 import me.ShermansWorld.AlathraExtras.tpacooldown.listener.essentialsx.PreTeleportListener;
 import me.ShermansWorld.AlathraExtras.tpacooldown.listener.essentialsx.TeleportRequestResponseListener;
@@ -162,6 +163,7 @@ public class AlathraExtras extends JavaPlugin {
         // this.getServer().getPluginManager().registerEvents(new BookEventsListener(), this);
         // This is broken do not enable unless you have confirmed its working.
         this.getServer().getPluginManager().registerEvents(new ItemConverter(), this);
+        this.getServer().getPluginManager().registerEvents(new TownyMenu(), this);
 
         initRecipeItems();
         FurnaceRecipes furnaceRecipes = new FurnaceRecipes();

--- a/src/main/java/me/ShermansWorld/AlathraExtras/towny/TownyMenu.java
+++ b/src/main/java/me/ShermansWorld/AlathraExtras/towny/TownyMenu.java
@@ -1,0 +1,53 @@
+package me.ShermansWorld.AlathraExtras.towny;
+
+import java.util.ArrayList;
+
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+
+import com.palmergames.adventure.text.Component;
+import com.palmergames.adventure.text.event.HoverEvent;
+import com.palmergames.bukkit.towny.event.statusscreen.TownStatusScreenEvent;
+import com.palmergames.bukkit.towny.object.Resident;
+import com.palmergames.bukkit.towny.object.Town;
+import com.palmergames.bukkit.util.Colors;
+
+public class TownyMenu implements Listener {
+	
+	@EventHandler(priority = EventPriority.LOW)
+	public void onTownStatusScreen(TownStatusScreenEvent event) {
+		
+		Town town = event.getTown();
+		ArrayList<Resident> activeResidents = new ArrayList<Resident>();
+		for (Resident resident : town.getResidents()) {
+			long now = System.currentTimeMillis();
+			long lastPlayed = resident.getLastOnline();
+			long lastOnline = now - lastPlayed; // miliseconds player has been offline
+			long milisecPerDay = 1000 * 60 * 60 * 24; // 1000 milisec/sec * 60 sec/min * 60 min/hr * 24 hr/day
+			long limit = milisecPerDay * 30;
+			if (lastOnline < limit) {
+				activeResidents.add(resident);
+			}
+		}
+		String activeResidentsStr = "&2Active Residents (Online in the last 30 days) &a[" + String.valueOf(activeResidents.size() + "]:&r ");
+		for (Resident resident : activeResidents) {
+			activeResidentsStr += resident.getName() + ", ";
+		}
+		
+		// Remove the last comma and space
+		activeResidentsStr = activeResidentsStr.substring(0, activeResidentsStr.length() -2);
+		
+		// Translate legancy color codes
+		activeResidentsStr = Colors.translateColorCodes(activeResidentsStr);
+		
+		// Build component
+		Component component = Component.empty();
+		component = component
+				.append(Component.text(Colors.translateColorCodes("&7[&aActive Residents&7]&r")).hoverEvent(HoverEvent.showText(Component.text(activeResidentsStr))));
+		component = component.append(Component.newline());
+		
+		// Add component to Towny Menu
+		event.getStatusScreen().addComponentOf("AlathraExtras", component);
+	}
+}


### PR DESCRIPTION
Added a component to the /t Town Menu which displays inactive residents (residents that have been not logged on for more than 30 days)

