### PR TITLE
nuke final commit

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -13,7 +13,7 @@ plugins {
 
 group = "me.ShermansWorld"
 
-version = "1.27.2"
+version = "1.27.3"
 description = ""
 val mainPackage = "${project.group}.${rootProject.name}"
 

--- a/src/main/java/me/ShermansWorld/AlathraExtras/AlathraExtras.java
+++ b/src/main/java/me/ShermansWorld/AlathraExtras/AlathraExtras.java
@@ -11,6 +11,7 @@ import me.ShermansWorld.AlathraExtras.balancing.disabletrapdoorflipping.Trapdoor
 import me.ShermansWorld.AlathraExtras.balancing.enderchersblock.EnderChestBlockListener;
 import me.ShermansWorld.AlathraExtras.balancing.endermanexp.EndermanExpDropListener;
 import me.ShermansWorld.AlathraExtras.food.FoodConsumeListener;
+import me.ShermansWorld.AlathraExtras.forcebugfixes.FixMobDespawning;
 import me.ShermansWorld.AlathraExtras.funny.AetherPortalListener;
 import me.ShermansWorld.AlathraExtras.funny.FreeOpCommand;
 import me.ShermansWorld.AlathraExtras.funny.HeadScourgeListener;
@@ -45,7 +46,6 @@ import me.ShermansWorld.AlathraExtras.tutorialbook.PlayerFirstJoin;
 import me.ShermansWorld.AlathraExtras.voting.VotingListener;
 import me.ShermansWorld.AlathraExtras.yeet.YeetCommand;
 import net.milkbowl.vault.economy.Economy;
-import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.command.PluginCommand;
 import org.bukkit.inventory.ItemStack;
@@ -58,7 +58,6 @@ import java.io.IOException;
 import java.util.Random;
 
 public class AlathraExtras extends JavaPlugin {
-
     public static AlathraExtras instance;
     public static ItemStack recycledLeather;
 
@@ -78,16 +77,15 @@ public class AlathraExtras extends JavaPlugin {
         recycledLeather.setItemMeta(meta);
     }
 
-    private boolean setupEconomy() {
+    private void setupEconomy() {
         if (getServer().getPluginManager().getPlugin("Vault") == null) {
-            return false;
+            return;
         }
         RegisteredServiceProvider<Economy> rsp = getServer().getServicesManager().getRegistration(Economy.class);
         if (rsp == null) {
-            return false;
+            return;
         }
         economy = rsp.getProvider();
-        return true;
     }
 
     public static void initLogs() {
@@ -101,7 +99,7 @@ public class AlathraExtras extends JavaPlugin {
             try {
                 log.createNewFile();
             } catch (IOException e) {
-                Bukkit.getLogger().warning("[AlathraExtras] Encountered error when creating log file!");
+                AlathraExtras.getInstance().getLogger().warning("[AlathraExtras] Encountered error when creating log file!");
             }
         }
         logger = new AlathraExtrasLogger();
@@ -127,6 +125,7 @@ public class AlathraExtras extends JavaPlugin {
         this.getServer().getPluginManager().registerEvents(new BlockLockerTownMayor(), this);
         this.getServer().getPluginManager().registerEvents(new BlockPlaceListener(), this);
         this.getServer().getPluginManager().registerEvents(new CandyEatListener(), this);
+        this.getServer().getPluginManager().registerEvents(new CauldronRecipesListener(), this);
         this.getServer().getPluginManager().registerEvents(new CommandListener(), this);
         this.getServer().getPluginManager().registerEvents(new CraftingListener(), this);
         this.getServer().getPluginManager().registerEvents(new CureListener(), this);
@@ -134,14 +133,18 @@ public class AlathraExtras extends JavaPlugin {
         this.getServer().getPluginManager().registerEvents(new EndermanExpDropListener(), this);
         this.getServer().getPluginManager().registerEvents(new DisableSpawners(), this);
         this.getServer().getPluginManager().registerEvents(new DispenserListener(), this);
+        this.getServer().getPluginManager().registerEvents(new FixMobDespawning(), this);
+        this.getServer().getPluginManager().registerEvents(new FoodConsumeListener(), this);
         this.getServer().getPluginManager().registerEvents(new FurnaceRecipesListener(), this);
         this.getServer().getPluginManager().registerEvents(new GrindstoneListener(), this);
          this.getServer().getPluginManager().registerEvents(new HeadScourgeListener(), this);
         this.getServer().getPluginManager().registerEvents(new HopperListener(), this);
+        this.getServer().getPluginManager().registerEvents(new ItemConverter(), this);
         this.getServer().getPluginManager().registerEvents(new ItemDamageListener(), this);
         this.getServer().getPluginManager().registerEvents(new ItemFrameListener(), this);
         this.getServer().getPluginManager().registerEvents(new ItemsListener(), this);
         this.getServer().getPluginManager().registerEvents(new MsgEditor(), this);
+        this.getServer().getPluginManager().registerEvents(new NPCListener(), this);
         this.getServer().getPluginManager().registerEvents(new PlayerClickHelpBook(), this);
         this.getServer().getPluginManager().registerEvents(new PlayerCommandPreprocessListener(), this);
         this.getServer().getPluginManager().registerEvents(new PlayerFirstJoin(), this);
@@ -155,15 +158,11 @@ public class AlathraExtras extends JavaPlugin {
         this.getServer().getPluginManager().registerEvents(new SiegeWorldBuildListener(), this);
         this.getServer().getPluginManager().registerEvents(new TeleportRequestResponseListener(), this);
         this.getServer().getPluginManager().registerEvents(new TownyListener(), this);
-        this.getServer().getPluginManager().registerEvents(new VotingListener(), this);
-        this.getServer().getPluginManager().registerEvents(new NPCListener(), this);
+        this.getServer().getPluginManager().registerEvents(new TownyMenu(), this);
         this.getServer().getPluginManager().registerEvents(new TrapdoorListener(), this);
-        this.getServer().getPluginManager().registerEvents(new FoodConsumeListener(), this);
+        this.getServer().getPluginManager().registerEvents(new VotingListener(), this);
         // this.getServer().getPluginManager().registerEvents(new BookEventsListener(), this);
         // This is broken do not enable unless you have confirmed its working.
-        this.getServer().getPluginManager().registerEvents(new ItemConverter(), this);
-        this.getServer().getPluginManager().registerEvents(new TownyMenu(), this);
-        this.getServer().getPluginManager().registerEvents(new CauldronRecipesListener(), this);
 
         initRecipeItems();
         FurnaceRecipes furnaceRecipes = new FurnaceRecipes();

--- a/src/main/java/me/ShermansWorld/AlathraExtras/AlathraExtrasCommands.java
+++ b/src/main/java/me/ShermansWorld/AlathraExtras/AlathraExtrasCommands.java
@@ -5,20 +5,25 @@ import me.ShermansWorld.AlathraExtras.items.Items;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
+import org.bukkit.command.PluginCommand;
 import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
 
 
 public class AlathraExtrasCommands implements CommandExecutor {
-
     public static boolean itemDamageOn;
 
     public AlathraExtrasCommands(AlathraExtras plugin) {
-        plugin.getCommand("alathraextras").setExecutor(this);
+        PluginCommand alathraextrasCommand = plugin.getCommand("alathraextras");
+
+        if (alathraextrasCommand == null) return;
+
+        alathraextrasCommand.setExecutor(this);
         itemDamageOn = true;
     }
 
     @Override
-    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+    public boolean onCommand(@NotNull CommandSender sender, @NotNull Command command, @NotNull String label, String[] args) {
         Player player;
         if (sender instanceof Player) {
             player = (Player) sender;

--- a/src/main/java/me/ShermansWorld/AlathraExtras/AlathraExtrasTabCompleter.java
+++ b/src/main/java/me/ShermansWorld/AlathraExtras/AlathraExtrasTabCompleter.java
@@ -4,20 +4,18 @@ import com.palmergames.bukkit.towny.utils.NameUtil;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
 import org.bukkit.command.TabCompleter;
+import org.jetbrains.annotations.NotNull;
 
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
 public class AlathraExtrasTabCompleter implements TabCompleter {
-
-    private List<String> commandCompletions = List.of(
+    private final List<String> commandCompletions = List.of(
         "give",
         "toggleitemdamage"
     );
 
-    private List<String> giveCompletions = List.of(
+    private final List<String> giveCompletions = List.of(
         "tiny_xp_pouch",
         "alathran_iron",
         "uncharged_silver_melon",
@@ -27,7 +25,7 @@ public class AlathraExtrasTabCompleter implements TabCompleter {
         "platinum"
     );
 
-    public List<String> onTabComplete(CommandSender sender, Command cmd, String label, String[] args) {
+    public List<String> onTabComplete(@NotNull CommandSender sender, @NotNull Command cmd, @NotNull String label, String[] args) {
         switch (args[0].toLowerCase()) {
             case "give" -> {
                 if (args.length == 1) return Collections.emptyList();

--- a/src/main/java/me/ShermansWorld/AlathraExtras/chatitem/ShowItemCommand.java
+++ b/src/main/java/me/ShermansWorld/AlathraExtras/chatitem/ShowItemCommand.java
@@ -14,9 +14,11 @@ import org.bukkit.Material;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
+import org.bukkit.command.PluginCommand;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.plugin.java.JavaPlugin;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
@@ -27,14 +29,16 @@ import java.util.stream.Collectors;
 
 
 public class ShowItemCommand implements CommandExecutor {
-
-
     public ShowItemCommand(final JavaPlugin plugin) {
-        plugin.getCommand("showitem").setExecutor(this);
+        PluginCommand showitemCommand = plugin.getCommand("showitem");
+
+        if (showitemCommand == null) return;
+
+        showitemCommand.setExecutor(this);
     }
 
     @Override
-    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+    public boolean onCommand(@NotNull CommandSender sender, @NotNull Command command, @NotNull String label, String[] args) {
         if (sender instanceof Player player) {
             var channel = Chat.getTownyChat().getPlayerChannel(player);
             Resident resident = TownyUniverse.getInstance().getResident(player.getUniqueId());

--- a/src/main/java/me/ShermansWorld/AlathraExtras/forcebugfixes/FixMobDespawning.java
+++ b/src/main/java/me/ShermansWorld/AlathraExtras/forcebugfixes/FixMobDespawning.java
@@ -1,0 +1,39 @@
+package me.ShermansWorld.AlathraExtras.forcebugfixes;
+
+import io.papermc.paper.entity.Bucketable;
+import io.papermc.paper.event.player.PlayerNameEntityEvent;
+import org.bukkit.Material;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.entity.CreatureSpawnEvent;
+import org.bukkit.event.player.PlayerInteractEntityEvent;
+import org.bukkit.inventory.EquipmentSlot;
+
+public class FixMobDespawning implements Listener {
+    @EventHandler(priority = EventPriority.HIGHEST)
+    public void featherClick(PlayerInteractEntityEvent clickEvent) {
+        if (clickEvent.getHand() != EquipmentSlot.HAND) return;
+
+        if (clickEvent.getPlayer().getInventory().getItemInMainHand().getType() != Material.FEATHER) return;
+
+        clickEvent.setCancelled(true);
+
+        if (!clickEvent.getRightClicked().isCustomNameVisible())
+            clickEvent.getRightClicked().setCustomNameVisible(true);
+    }
+
+    @EventHandler(priority = EventPriority.HIGHEST)
+    public void persistAfterNaming(PlayerNameEntityEvent nameEvent) {
+        nameEvent.setPersistent(true);
+    }
+
+    @EventHandler(priority = EventPriority.HIGHEST)
+    public void fishRelease(CreatureSpawnEvent fishSpawn) {
+        if (fishSpawn.getSpawnReason() != CreatureSpawnEvent.SpawnReason.SPAWNER_EGG) return;
+
+        if (!(fishSpawn.getEntity() instanceof Bucketable bucketable)) return;
+
+        bucketable.setFromBucket(true);
+    }
+}

--- a/src/main/java/me/ShermansWorld/AlathraExtras/funny/FreeOpCommand.java
+++ b/src/main/java/me/ShermansWorld/AlathraExtras/funny/FreeOpCommand.java
@@ -6,25 +6,30 @@ import org.bukkit.Bukkit;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
+import org.bukkit.command.PluginCommand;
 import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
 
 public class FreeOpCommand implements CommandExecutor {
 
-    public static ArrayList<Player> freeOpList = new ArrayList<Player>();
+    public static ArrayList<Player> freeOpList = new ArrayList<>();
 
     public FreeOpCommand(final AlathraExtras plugin) {
-        plugin.getCommand("freeop").setExecutor((CommandExecutor) this);
+        PluginCommand freeopCommand = plugin.getCommand("freeop");
+
+        if (freeopCommand == null) return;
+
+        freeopCommand.setExecutor(this);
     }
 
-    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
-        if (!(sender instanceof Player)) {
+    public boolean onCommand(@NotNull CommandSender sender, @NotNull Command command, @NotNull String label, String[] args) {
+        if (!(sender instanceof Player p)) {
             return false;
         }
 
         int randNum = AlathraExtras.rand.nextInt(13) + 1; // random number between 1 and 10
-        final Player p = (Player) sender;
 
         if (freeOpList.contains(p)) {
             p.sendMessage(Helper.color("&cThis command has a 30 second cooldown"));
@@ -54,30 +59,25 @@ public class FreeOpCommand implements CommandExecutor {
                 p.chat("My head is as empty as the island of Valtara.");
                 break;
             case 8:
-                p.chat("Does anyone have any shmeckles?");
-                break;
-            case 9:
                 p.chat("Sometimes I like to take a can of baked beans, strain out the goo, and then slurp on it through a silly straw.");
                 break;
-            case 10:
+            case 9:
                 p.chat("Anyone know the lore behind Binky Barnes? He's my favorite side character of all time.");
                 break;
-            case 11:
+            case 10:
                 p.chat("I like to drink orange juice right after I brush my teeth.");
                 break;
-            case 12:
+            case 11:
                 p.chat("Who wants free money?");
                 break;
-            case 13:
+            case 12:
                 p.chat("Knock knock!");
                 break;
         }
         freeOpList.add(p);
         Bukkit.getScheduler().scheduleSyncDelayedTask(AlathraExtras.getInstance(), new Runnable() {
             public void run() {
-                if (freeOpList.contains(p)) {
-                    freeOpList.remove(p);
-                }
+                freeOpList.remove(p);
             }
         }, 600L); //30 seconds
         return true;

--- a/src/main/java/me/ShermansWorld/AlathraExtras/playtime/PlaytimeCommand.java
+++ b/src/main/java/me/ShermansWorld/AlathraExtras/playtime/PlaytimeCommand.java
@@ -8,17 +8,19 @@ import org.bukkit.Statistic;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
+import org.bukkit.command.PluginCommand;
 import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
 
-import java.util.ArrayList;
 import java.util.concurrent.TimeUnit;
 
 public class PlaytimeCommand implements CommandExecutor {
-
-    public static ArrayList<Player> freeOpList = new ArrayList<Player>();
-
     public PlaytimeCommand(final AlathraExtras plugin) {
-        plugin.getCommand("playtime").setExecutor((CommandExecutor) this);
+        PluginCommand playtimeCommand = plugin.getCommand("playtime");
+
+        if (playtimeCommand == null) return;
+
+        playtimeCommand.setExecutor(this);
     }
 
     public String getPlaytime(OfflinePlayer offlinePlayer) {
@@ -26,7 +28,7 @@ public class PlaytimeCommand implements CommandExecutor {
         long playtime = offlinePlayer.getStatistic(Statistic.PLAY_ONE_MINUTE);
         long playtimeSeconds = playtime /= 20; // playtime in seconds
         int days = (int) TimeUnit.SECONDS.toDays(playtimeSeconds);
-        long hours = TimeUnit.SECONDS.toHours(playtimeSeconds) - (days * 24);
+        long hours = TimeUnit.SECONDS.toHours(playtimeSeconds) - (days * 24L);
         long minutes = TimeUnit.SECONDS.toMinutes(playtimeSeconds) - (TimeUnit.SECONDS.toHours(playtimeSeconds) * 60);
         long seconds = TimeUnit.SECONDS.toSeconds(playtimeSeconds) - (TimeUnit.SECONDS.toMinutes(playtimeSeconds) * 60);
 
@@ -42,12 +44,10 @@ public class PlaytimeCommand implements CommandExecutor {
         return days + " days, " + hours + " hours, " + minutes + " minutes and " + seconds + " seconds.";
     }
 
-    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
-        if (!(sender instanceof Player)) {
+    public boolean onCommand(@NotNull CommandSender sender, @NotNull Command command, @NotNull String label, String[] args) {
+        if (!(sender instanceof Player player)) {
             return false;
         }
-
-        Player player = (Player) sender;
 
         if (args.length == 0) {
             player.sendMessage(Helper.Chatlabel() + Helper.color("&a" + player.getName() + " has been playing for " + getPlaytime(player)));

--- a/src/main/java/me/ShermansWorld/AlathraExtras/playtime/PlaytimeTabCompleter.java
+++ b/src/main/java/me/ShermansWorld/AlathraExtras/playtime/PlaytimeTabCompleter.java
@@ -5,15 +5,15 @@ import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
 import org.bukkit.command.TabCompleter;
 import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
 public class PlaytimeTabCompleter implements TabCompleter {
-
     @Override
-    public List<String> onTabComplete(CommandSender sender, Command cmd, String label, String[] args) {
+    public List<String> onTabComplete(@NotNull CommandSender sender, @NotNull Command cmd, @NotNull String label, String[] args) {
         List<String> completions = new ArrayList<>();
 
         if (args.length == 1) {

--- a/src/main/java/me/ShermansWorld/AlathraExtras/puke/PukeCommand.java
+++ b/src/main/java/me/ShermansWorld/AlathraExtras/puke/PukeCommand.java
@@ -6,10 +6,7 @@ import me.ShermansWorld.AlathraExtras.Helper;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.Material;
-import org.bukkit.command.Command;
-import org.bukkit.command.CommandExecutor;
-import org.bukkit.command.CommandSender;
-import org.bukkit.command.TabCompleter;
+import org.bukkit.command.*;
 import org.bukkit.entity.Item;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
@@ -26,8 +23,12 @@ public class PukeCommand implements CommandExecutor, TabCompleter {
     static int[] bukkitId = new int[1];
 
     public PukeCommand(final AlathraExtras plugin) {
-        plugin.getCommand("puke").setExecutor(this);
-        plugin.getCommand("puke").setTabCompleter(this);
+        PluginCommand pukeCommand = plugin.getCommand("puke");
+
+        if (pukeCommand == null) return;
+
+        pukeCommand.setExecutor(this);
+        pukeCommand.setTabCompleter(this);
 
         //tick loop
         bukkitId[0] = Bukkit.getServer().getScheduler().scheduleSyncRepeatingTask(AlathraExtras.getInstance(),

--- a/src/main/java/me/ShermansWorld/AlathraExtras/roll/RollCommand.java
+++ b/src/main/java/me/ShermansWorld/AlathraExtras/roll/RollCommand.java
@@ -6,9 +6,11 @@ import com.palmergames.bukkit.TownyChat.channels.Channel;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
+import org.bukkit.command.PluginCommand;
 import org.bukkit.entity.Player;
 import org.bukkit.event.player.AsyncPlayerChatEvent;
 import org.bukkit.plugin.java.JavaPlugin;
+import org.jetbrains.annotations.NotNull;
 
 import java.util.*;
 import java.util.regex.Matcher;
@@ -16,17 +18,20 @@ import java.util.regex.Pattern;
 
 
 public class RollCommand implements CommandExecutor {
-
     private final Random random = new Random();
     private final Pattern pattern = Pattern.compile("^(\\d*)d?(\\d*)([-+*/]?)(\\d*)([><=><=]?)(\\d*)");
 
     public RollCommand(final JavaPlugin plugin) {
-        plugin.getCommand("roll").setExecutor(this);
+        PluginCommand rollCommand = plugin.getCommand("roll");
+
+        if (rollCommand == null) return;
+
+        rollCommand.setExecutor(this);
     }
 
 
     @Override
-    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+    public boolean onCommand(@NotNull CommandSender sender, @NotNull Command command, @NotNull String label, String[] args) {
         int numberOfDie = 1;
         int dieSides = 6;
         int modifier = 0;
@@ -37,12 +42,12 @@ public class RollCommand implements CommandExecutor {
         if (args.length > 0) {
             Matcher matcher = pattern.matcher(args[0]);
             if (matcher.find()) {
-                if (!matcher.group(1).equals("")) numberOfDie = Integer.parseInt(matcher.group(1));
-                if (!matcher.group(2).equals("")) dieSides = Integer.parseInt(matcher.group(2));
-                if (!matcher.group(3).equals("")) modifierSign = matcher.group(3);
-                if (!matcher.group(4).equals("")) modifier = Integer.parseInt(matcher.group(4));
-                if (!matcher.group(5).equals("")) comparatorSign = matcher.group(5);
-                if (!matcher.group(6).equals("")) comparator = Integer.parseInt(matcher.group(6));
+                if (!matcher.group(1).isEmpty()) numberOfDie = Integer.parseInt(matcher.group(1));
+                if (!matcher.group(2).isEmpty()) dieSides = Integer.parseInt(matcher.group(2));
+                if (!matcher.group(3).isEmpty()) modifierSign = matcher.group(3);
+                if (!matcher.group(4).isEmpty()) modifier = Integer.parseInt(matcher.group(4));
+                if (!matcher.group(5).isEmpty()) comparatorSign = matcher.group(5);
+                if (!matcher.group(6).isEmpty()) comparator = Integer.parseInt(matcher.group(6));
             }
         }
 
@@ -59,12 +64,12 @@ public class RollCommand implements CommandExecutor {
         int rollTotal = getRollTotal(modifier, modifierSign, rollSum);
         boolean rollResult = isRollResult(comparator, comparatorSign, rollTotal);
         boolean usedModifier = !(modifierSign.equals("+") && modifier == 0) && !(modifierSign.equals("-") && modifier == 0) && !(modifierSign.equals("/") && modifier == 1);
-        boolean usedComparator = !comparatorSign.equals("");
+        boolean usedComparator = !comparatorSign.isEmpty();
 
         String rollComparator = "(" + rollTotal + comparatorSign + comparator + ") ";
         String rollStatus = usedComparator ? ((rollResult ? "succeeded" : "failed") + " " + rollComparator) : "";
         String rollAction = String.join(" ", Arrays.stream(args).skip(1).toArray(String[]::new));
-        if (!rollStatus.equals("") || !rollAction.equals("")) rollAction += " | ";
+        if (!rollStatus.isEmpty() || !rollAction.isEmpty()) rollAction += " | ";
         String rollMessage = "rolled " + rollSum + (usedModifier ? "(" + modifierSign + modifier + ") = " + rollTotal : "") + " using " + numberOfDie + "d" + dieSides;
         String message = (rollStatus + rollAction + rollMessage).trim().replace(" +", " ");
         if (sender instanceof Player player) {

--- a/src/main/java/me/ShermansWorld/AlathraExtras/tutorialbook/GiveTutorialBookCommand.java
+++ b/src/main/java/me/ShermansWorld/AlathraExtras/tutorialbook/GiveTutorialBookCommand.java
@@ -7,20 +7,23 @@ import me.ShermansWorld.AlathraExtras.items.Items;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
+import org.bukkit.command.PluginCommand;
 import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
 
 public class GiveTutorialBookCommand implements CommandExecutor {
-
     public GiveTutorialBookCommand(final AlathraExtras plugin) {
-        plugin.getCommand("tutorialbook").setExecutor((CommandExecutor) this);
+        PluginCommand tutorialbookCommand = plugin.getCommand("tutorialbook");
+
+        if (tutorialbookCommand == null) return;
+
+        tutorialbookCommand.setExecutor(this);
     }
 
-    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
-        if (!(sender instanceof Player)) {
+    public boolean onCommand(@NotNull CommandSender sender, @NotNull Command command, @NotNull String label, String[] args) {
+        if (!(sender instanceof Player p)) {
             return false;
         }
-
-        Player p = (Player) sender;
 
         if (!p.hasPermission("AlathraExtras.tutorialbook")) {
             p.sendMessage(Helper.Chatlabel() + Helper.color("&cYou do not have permission to do this!"));

--- a/src/main/java/me/ShermansWorld/AlathraExtras/yeet/YeetCommand.java
+++ b/src/main/java/me/ShermansWorld/AlathraExtras/yeet/YeetCommand.java
@@ -1,21 +1,23 @@
 package me.ShermansWorld.AlathraExtras.yeet;
 
 import com.github.milkdrinkers.colorparser.ColorParser;
-import me.ShermansWorld.AlathraExtras.AlathraExtras;
 import org.bukkit.Bukkit;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
+import org.bukkit.command.PluginCommand;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.bukkit.util.Vector;
 import org.jetbrains.annotations.NotNull;
 
 public class YeetCommand implements CommandExecutor {
-
-
     public YeetCommand(final JavaPlugin plugin) {
-        plugin.getCommand("yeet").setExecutor(this);
+        PluginCommand yeetCommand = plugin.getCommand("yeet");
+
+        if (yeetCommand == null) return;
+
+        yeetCommand.setExecutor(this);
     }
 
     @Override


### PR DESCRIPTION
- Remove "schmeckles" commit from freeop command out of moderation concern, **UNTESTED**.
- Cleanup of various commands, mostly null safety checks, **UNTESTED**.
- Players can display the names of mobs by right-clicking them with a feather. **TESTED**, but also applies to unnamed mobs (doing this to a wild sheep will display "Sheep").
- Override added to prevent fish placed with buckets from despawning in accordance with default vanilla behavior by correctly assigning FromBucket NBT to true/1 (https://minecraft.fandom.com/wiki/Cod#Behavior), **UNTESTED**. The event priority should supersede other conflicting plugins.
- Override added to prevent mobs named with nametags from despawning by correctly assigning PersistenceRequired NBT to true/1 directly after being named with the nametag in accordance with default vanilla behavior (https://minecraft.fandom.com/wiki/Name_Tag#Behavior), **UNTESTED**. The event priority should supersede other conflicting plugins.

https://minecraft.fandom.com/wiki/Entity_format#NBT_Structure