### PR TITLE
feat: add and register rooted dirt crafting recipe

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -13,7 +13,7 @@ plugins {
 
 group = "me.ShermansWorld"
 
-version = "1.29.0"
+version = "1.29.1"
 description = ""
 val mainPackage = "${project.group}.${rootProject.name}"
 

--- a/src/main/java/me/ShermansWorld/AlathraExtras/crafting/CraftingRecipes.java
+++ b/src/main/java/me/ShermansWorld/AlathraExtras/crafting/CraftingRecipes.java
@@ -271,6 +271,17 @@ public class CraftingRecipes {
 
         AlathraExtras.getInstance().getServer().addRecipe(cryingObsidianRecipe);
     }
+
+    public static void rootedDirtRecipe() {
+        ItemStack rootedDirt = new ItemStack(Material.ROOTED_DIRT, 8);
+        NamespacedKey key = new NamespacedKey(AlathraExtras.getInstance(),
+            AlathraExtras.getInstance().getName() + "rootedDirtRecipe");
+        ShapedRecipe rootedDirtRecipe = new ShapedRecipe(key, rootedDirt);
+        rootedDirtRecipe.shape("CCC", "CHC", "CCC");
+        rootedDirtRecipe.setIngredient('C', Material.COARSE_DIRT);
+        rootedDirtRecipe.setIngredient('H', Material.HANGING_ROOTS);
+        AlathraExtras.getInstance().getServer().addRecipe(rootedDirtRecipe);
+    }
     
     public static Recipe trebuchetRecipe() {
 		ItemStack trebuchet = SiegeEnginesAPI.getTrebuchetItem();
@@ -622,6 +633,7 @@ public class CraftingRecipes {
 
     public static void registerAllCraftingRecipes() {
         saddleRecipe();
+        rootedDirtRecipe();
         charcoalBlock();
         redDyeRecipe();
         redSandRecipe();


### PR DESCRIPTION
### Description

This pull request adds and registers a new crafting recipe for rooted dirt in the AlathraExtras plugin.

### Changes

- Added a new crafting recipe for rooted dirt.
- Updated `CraftingRecipes.java` to include the new recipe.
- Ensured the new recipe is registered in the `registerAllCraftingRecipes` method.

### How to Test

1. Compile and run the plugin.
2. Verify that the new crafting recipe for rooted dirt is available and functional in the game.
3. Check that the item is correctly crafted and has the expected properties.

### Related Issues

- None

### Additional Notes

- Ensure that the server is restarted after adding the plugin to apply the new recipe.