### PR TITLE
Add new crafting recipes for rails and powered rails

### DIFF
--- a/src/main/java/me/ShermansWorld/AlathraExtras/crafting/CraftingRecipes.java
+++ b/src/main/java/me/ShermansWorld/AlathraExtras/crafting/CraftingRecipes.java
@@ -156,6 +156,29 @@ public class CraftingRecipes {
         AlathraExtras.getInstance().getServer().addRecipe(pinkPetalsRecipe);
     }
 
+    public static void railsRecipe() {
+        ItemStack rails = new ItemStack(Material.RAIL, 64);
+        NamespacedKey key = new NamespacedKey(AlathraExtras.getInstance(),
+            AlathraExtras.getInstance().getName() + "railsRecipe");
+        ShapedRecipe railsRecipe = new ShapedRecipe(key, rails);
+        railsRecipe.shape("I I", "ISI", "I I");
+        railsRecipe.setIngredient('I', Material.IRON_INGOT);
+        railsRecipe.setIngredient('S', Material.STICK);
+        AlathraExtras.getInstance().getServer().addRecipe(railsRecipe);
+    }
+
+    public static void poweredRailsRecipe() {
+        ItemStack poweredRails = new ItemStack(Material.POWERED_RAIL,  24);
+        NamespacedKey key = new NamespacedKey(AlathraExtras.getInstance(),
+            AlathraExtras.getInstance().getName() + "poweredRailsRecipe");
+        ShapedRecipe poweredRailsRecipe = new ShapedRecipe(key, poweredRails);
+        poweredRailsRecipe.shape("G G", "GSG", "GRG");
+        poweredRailsRecipe.setIngredient('G', Material.GOLD_INGOT);
+        poweredRailsRecipe.setIngredient('S', Material.STICK);
+        poweredRailsRecipe.setIngredient('R', Material.REDSTONE);
+        AlathraExtras.getInstance().getServer().addRecipe(poweredRailsRecipe);
+    }
+
     public static void stonesToGravel(int a) {
         for (int b = 0; b <= a; b++) {
             NamespacedKey key = new NamespacedKey(AlathraExtras.getInstance(),
@@ -674,5 +697,7 @@ public class CraftingRecipes {
         mustacheRecipe();
         crownRecipe();
         wreathRecipe();
+        railsRecipe();
+        poweredRailsRecipe();
     }
 }


### PR DESCRIPTION
### Description

This PR adds new crafting recipes for rails and powered rails in the `AlathraExtras` plugin.

### Changes

- Added a new crafting recipe for rails that yields 64 rails per craft.
- Added a new crafting recipe for powered rails that yields 24 powered rails per craft.
- Updated the `registerAllCraftingRecipes` method to include the new recipes.

### How to Test

1. Compile and run the plugin.
2. Verify that the new crafting recipe for rails and powered rails are available and functional in the game.
3. Check that the item is correctly crafted and has the expected properties.

### Related Issues
- Recipes don't update in JEI/REI, even though they craft correctly.

### Additional notes
- Ensure that the server is restarted after adding the plugin to apply the new recipe.
- The recipes are just the original recipes but with 4x the result.